### PR TITLE
Don't duplicate Transfer-Encoding header.

### DIFF
--- a/lua/nginx_lua_chunkedup.lua
+++ b/lua/nginx_lua_chunkedup.lua
@@ -46,7 +46,6 @@ local gen_boundary = function()
 end
 
 ngx.status = 200
-ngx.header['Transfer-Encoding'] = 'chunked'
 ngx.send_headers()
 ngx.flush(true)
 


### PR DESCRIPTION
Remove duplicate header.