### PR TITLE
Add keepalive.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openresty/openresty:centos
 
-RUN yum install -y gcc && \
+RUN yum install -y gcc git && \
     yum clean all && \
     rm -rf /var/cache/yum
 
@@ -8,6 +8,7 @@ RUN opm get openresty/lua-resty-upload
 RUN luarocks install luafilesystem
 RUN luarocks install luaposix
 RUN luarocks install lpeg
+RUN luarocks install lua-resty-httpipe
 
 RUN curl -o /tmp/nginx-lua-upload-module.zip -L \
     https://github.com/btimby/nginx-lua-upload-module/archive/master.zip && \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ post:
 
 .PHONY: put
 put:
-	curl -i -X PUT -H "Transfer-Encoding: chunked" -H 'Content-Type: text/plain' -H 'X-File-Name: foobar.txt' \
+	curl -i -X PUT -H "Transfer-Encoding: chunked" -H 'Cookie: foo=bar' -H 'Content-Type: text/plain' -H 'X-File-Name: foobar.txt' \
 		 --data-binary @fixtures/hello.txt http://localhost/upload/?foo=bar
 
 .PHONY: patch

--- a/docker/nginx/conf.d/chunkedup.conf
+++ b/docker/nginx/conf.d/chunkedup.conf
@@ -38,6 +38,7 @@ server {
         lua_code_cache off;
 
         set $backend_url /upstream/$path;
+        set $keepalive_url http://127.0.0.1/api/2/ping/;
         set $upload_store /tmp;
 
         content_by_lua_file '/usr/local/openresty/lualib/nginx_lua_chunkedup.lua';

--- a/lua/nginx_lua_chunkedup.lua
+++ b/lua/nginx_lua_chunkedup.lua
@@ -1,6 +1,7 @@
 local lfs = require('lfs')
 local posix = require('posix')
 local http_utils = require('nginx_upload.http_utils')
+local http = require('resty.httpipe')
 
 -- Determines what method to use for subrequest.
 local METHOD_MAP = {}
@@ -59,6 +60,33 @@ end
 
 local fd, ntmp = posix.mkstemp(UPLOAD_STORE .. '/chunkedup_XXXXXX')
 
+-- Poll backend to keep session alive.
+local function ping()
+    local url = ngx.var.keepalive_url
+
+    if url == nil or url == '' then
+        ngx.log(ngx.WARN, 'Keepalive disabled.')
+        return
+    end
+
+    local htp = http.new()
+    local scheme, host, port, path, args = unpack(htp:parse_uri(url))
+
+    while (true) do
+        local res, htpErr = htp:request(host, port, {
+            method='GET',
+            path=path,
+        })
+
+        if htpErr then
+            ngx.log(ngx.ERR, 'Error in session keepalive: ' .. htpErr)
+        end
+
+        -- Sleep for 5 minutes.
+        ngx.sleep(5 * 60)
+    end
+end
+
 -- We are now responsible for cleaning up ntmp...
 local function cleanup()
     os.remove(ntmp)
@@ -66,6 +94,8 @@ local function cleanup()
     ngx.exit(499)
 end
 ngx.on_abort(cleanup)
+
+local keepalive = ngx.thread.spawn(ping)
 
 while (true) do
     local data, typ, err
@@ -137,5 +167,7 @@ sock:send(string.format('%x', #r.body) .. '\r\n')
 sock:send(r.body .. '\r\n')
 sock:send('0\r\n')
 sock:send('\r\n')
+
+ngx.thread.kill(keepalive)
 
 ngx.exit(r.status)

--- a/lua/nginx_lua_chunkedup.lua
+++ b/lua/nginx_lua_chunkedup.lua
@@ -71,11 +71,23 @@ local function ping()
 
     local htp = http.new()
     local scheme, host, port, path, args = unpack(htp:parse_uri(url))
+    local options = {
+        method='GET',
+        path=path,
+    }
+
+    local cookie = headers['Cookie']
+    if (cookie == nil) then
+        ngx.log(ngx.WARN, 'No active session, keepalive skipped')
+        return
+    end
+    options['headers'] = { Cookie=cookie }
 
     while (true) do
         local res, htpErr = htp:request(host, port, {
             method='GET',
             path=path,
+            headers=reqHeaders,
         })
 
         if htpErr then


### PR DESCRIPTION
Added nginx light thread that periodically (every 5m) hits a configurable URL during upload handling. This ensures that the session is kept alive during the upload.

This is currently only necessary during a PUT request, since POST is utilized by the UI, and it already handles keepalive.

However, down the road, I want to integrate this with POST as well, then the UI will no longer need to worry about keepalive.
